### PR TITLE
PHP 8.4 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
         php-version:
         - "8.1"
         - "8.2"
+        - "8.4"
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG PHP_VERSION=8.1
-FROM php:${PHP_VERSION}-cli-buster
+FROM php:${PHP_VERSION}-cli-bookworm
 
 RUN apt-get update && \
 	apt-get install -y autoconf pkg-config && \

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,11 @@ test-container-82:
 	@-docker-compose run --rm app82 bash
 	@docker-compose down -v
 
+.PHONY: test-container-84
+test-container-84:
+	@-docker-compose run --rm app84 bash
+	@docker-compose down -v
+
 .PHONY: lint
 lint:
 	@XDEBUG_MODE=off phpcs -s

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,5 +34,23 @@ services:
     - ~/.composer:/root/.composer:delegated
     working_dir: /app
 
+  app84:
+      build:
+          context: .
+          dockerfile: Dockerfile
+          args:
+              PHP_VERSION: '8.4'
+      environment:
+          PHP_IDE_CONFIG: 'serverName=icanboogie-cldr'
+          ICANBOOGIE_CLDR_REDIS_HOST: redis
+          ICANBOOGIE_CLDR_REDIS_PORT: 6379
+      depends_on:
+          - redis
+      volumes:
+          - .:/app:delegated
+          - ~/.composer:/root/.composer:delegated
+      working_dir: /app
+
+
   redis:
     image: redis:5-alpine

--- a/src/Core/Locale.php
+++ b/src/Core/Locale.php
@@ -233,7 +233,7 @@ class Locale extends AbstractSectionCollection implements Localizable, Warmable
      *
      * @see NumberFormatterLocalized::format
      */
-    public function format_number(float|int|string $number, string $pattern = null): string
+    public function format_number(float|int|string $number, ?string $pattern = null): string
     {
         return $this->get_number_formatter()->format($number, $pattern);
     }
@@ -243,7 +243,7 @@ class Locale extends AbstractSectionCollection implements Localizable, Warmable
      *
      * @see NumberFormatterLocalized::format
      */
-    public function format_percent(float|int|string $number, string $pattern = null): string
+    public function format_percent(float|int|string $number, ?string $pattern = null): string
     {
         return $this->get_number_formatter()->format(
             $number,

--- a/src/Core/LocaleNotAvailable.php
+++ b/src/Core/LocaleNotAvailable.php
@@ -19,8 +19,8 @@ final class LocaleNotAvailable extends InvalidArgumentException implements Excep
      */
     public function __construct(
         public readonly string $locale_id,
-        string $message = null,
-        Throwable $previous = null
+        ?string $message = null,
+        ?Throwable $previous = null
     ) {
         $message ??= "Locale ID is not available: $locale_id";
 

--- a/src/Numbers/CurrencyFormatter.php
+++ b/src/Numbers/CurrencyFormatter.php
@@ -34,7 +34,7 @@ final class CurrencyFormatter implements Formatter, Localizable
         float|int|string $number,
         NumberPattern|string $pattern,
         ?Symbols $symbols = null,
-        ?string $currencySymbol = self::DEFAULT_CURRENCY_SYMBOL
+        string $currencySymbol = self::DEFAULT_CURRENCY_SYMBOL
     ): string {
         return str_replace(
             self::DEFAULT_CURRENCY_SYMBOL,

--- a/src/Numbers/CurrencyFormatter.php
+++ b/src/Numbers/CurrencyFormatter.php
@@ -33,8 +33,8 @@ final class CurrencyFormatter implements Formatter, Localizable
     public function format(
         float|int|string $number,
         NumberPattern|string $pattern,
-        Symbols $symbols = null,
-        string $currencySymbol = self::DEFAULT_CURRENCY_SYMBOL
+        ?Symbols $symbols = null,
+        ?string $currencySymbol = self::DEFAULT_CURRENCY_SYMBOL
     ): string {
         return str_replace(
             self::DEFAULT_CURRENCY_SYMBOL,

--- a/src/Numbers/CurrencyLocalized.php
+++ b/src/Numbers/CurrencyLocalized.php
@@ -37,7 +37,7 @@ final class CurrencyLocalized extends LocalizedObjectWithFormatter
      *
      * @param int|null $count Used for pluralization.
      */
-    public function name_for(int $count = null): string
+    public function name_for(?int $count = null): string
     {
         $offset = 'displayName';
 

--- a/src/Numbers/CurrencyNotDefined.php
+++ b/src/Numbers/CurrencyNotDefined.php
@@ -17,8 +17,8 @@ class CurrencyNotDefined extends InvalidArgumentException implements Exception
      */
     public function __construct(
         public readonly string $currency_code,
-        string $message = null,
-        Throwable $previous = null
+        ?string $message = null,
+        ?Throwable $previous = null
     ) {
         $message ??= "Currency code is not defined: $currency_code";
 

--- a/src/Numbers/Number.php
+++ b/src/Numbers/Number.php
@@ -51,7 +51,7 @@ final class Number
      *     `$number` has no decimal separator. The fractional part is returned as a string to preserve '03' from
      *     '1.03'.
      */
-    public static function parse(float|int|string $number, int $precision = null): array
+    public static function parse(float|int|string $number, ?int $precision = null): array
     {
         if ($precision === null) {
             $precision = self::precision_from($number);

--- a/src/Numbers/NumberFormatter.php
+++ b/src/Numbers/NumberFormatter.php
@@ -27,7 +27,7 @@ final class NumberFormatter implements Formatter, Localizable
     public function format(
         float|int|string $number,
         NumberPattern|string $pattern,
-        Symbols $symbols = null,
+        ?Symbols $symbols = null,
     ): string {
         if (!$pattern instanceof NumberPattern) {
             $pattern = NumberPattern::from($pattern);

--- a/src/Numbers/NumberFormatterLocalized.php
+++ b/src/Numbers/NumberFormatterLocalized.php
@@ -17,7 +17,7 @@ class NumberFormatterLocalized extends LocalizedObject implements Formatter
      *
      * @param float|int|numeric-string $number
      */
-    public function format(float|int|string $number, string $pattern = null): string
+    public function format(float|int|string $number, ?string $pattern = null): string
     {
         $numbers = $this->locale->numbers;
 

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -104,7 +104,7 @@ final class Repository
      *
      * @phpstan-ignore-next-line
      */
-    public function fetch(string $path, string $data_path = null): array
+    public function fetch(string $path, ?string $data_path = null): array
     {
         $data = $this->provider->provide($path);
 
@@ -134,7 +134,7 @@ final class Repository
     public function format_number(
         float|int|string $number,
         NumberPattern|string $pattern,
-        Symbols $symbols = null,
+        ?Symbols $symbols = null,
     ): string {
         return $this->number_formatter->format($number, $pattern, $symbols);
     }
@@ -150,7 +150,7 @@ final class Repository
     public function format_currency(
         float|int|string $number,
         NumberPattern|string $pattern,
-        Symbols $symbols = null,
+        ?Symbols $symbols = null,
         string $currencySymbol = CurrencyFormatter::DEFAULT_CURRENCY_SYMBOL
     ): string {
         return $this->currency_formatter->format($number, $pattern, $symbols, $currencySymbol);

--- a/src/Supplemental/Plurals/Operands.php
+++ b/src/Supplemental/Plurals/Operands.php
@@ -41,7 +41,7 @@ final class Operands
 
         [ $integer, $fractional ] = Number::parse($number);
 
-        $n = abs($number);
+        $n = abs($number + 0);
 
         if ($fractional === null || (int)$fractional === 0) {
             $n = (int)$n;

--- a/src/Supplemental/Territory/Territory.php
+++ b/src/Supplemental/Territory/Territory.php
@@ -189,7 +189,7 @@ final class Territory implements Localizable
      *
      * @throws Throwable
      */
-    public function currency_at(DateTimeInterface|string $date = null): ?Currency
+    public function currency_at(DateTimeInterface|string|null $date = null): ?Currency
     {
         $date = $this->ensure_is_datetime($date)->format('Y-m-d');
 

--- a/src/Supplemental/Territory/TerritoryNotDefined.php
+++ b/src/Supplemental/Territory/TerritoryNotDefined.php
@@ -17,8 +17,8 @@ final class TerritoryNotDefined extends InvalidArgumentException implements Exce
      */
     public function __construct(
         public readonly string $territory_code,
-        string $message = null,
-        Throwable $previous = null
+        ?string $message = null,
+        ?Throwable $previous = null
     ) {
         $message ??= "Territory not defined for code: $territory_code.";
 

--- a/tests/Numbers/CurrencyNotDefinedTest.php
+++ b/tests/Numbers/CurrencyNotDefinedTest.php
@@ -14,7 +14,7 @@ final class CurrencyNotDefinedTest extends TestCase
         string $currency_code,
         ?string $message,
         string $expected_message,
-        Exception $previous = null
+        ?Exception $previous = null
     ): void {
         $sut = new CurrencyNotDefined($currency_code, $message, $previous);
 

--- a/tests/Supplemental/Territory/TerritoryNotDefinedTest.php
+++ b/tests/Supplemental/Territory/TerritoryNotDefinedTest.php
@@ -14,7 +14,7 @@ final class TerritoryNotDefinedTest extends TestCase
         string $territory_code,
         ?string $message,
         string $expected_message,
-        Exception $previous = null
+        ?Exception $previous = null
     ): void {
         $sut = new TerritoryNotDefined($territory_code, $message, $previous);
 


### PR DESCRIPTION
This pull request adds ability to test code using PHP 8.4 images. 

- Switched from buster to bookworm as buster tags are not created for php 8.4.
- Added 8.4 version to docker compose in addition to github workflow
- Updated code and test deprecations